### PR TITLE
feat: 基本ヘルスチェックAPI実装完了 (Phase1.1.1)

### DIFF
--- a/apps/backend/src/app/app.module.ts
+++ b/apps/backend/src/app/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { HealthController } from './health.controller';
 
 @Module({
   imports: [],
-  controllers: [AppController],
+  controllers: [AppController, HealthController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/apps/backend/src/app/health.controller.spec.ts
+++ b/apps/backend/src/app/health.controller.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+  });
+
+  describe('GET /health', () => {
+    it('指定されたIDのユーザーを取得できる', async () => {
+      // Act: テスト実行（この時点では失敗する）
+      const result = await controller.getHealth();
+
+      // Assert: 結果検証
+      expect(result).toBeDefined();
+      expect(result.status).toBe('healthy');
+      expect(result.timestamp).toBeDefined();
+      expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
+    });
+
+    it('バージョン情報を含むレスポンスを返す', async () => {
+      // Act: テスト実行
+      const result = await controller.getHealth();
+
+      // Assert: 結果検証
+      expect(result.version).toBeDefined();
+      expect(typeof result.version).toBe('string');
+    });
+  });
+});

--- a/apps/backend/src/app/health.controller.ts
+++ b/apps/backend/src/app/health.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get } from '@nestjs/common';
+
+// 仮実装: スキーマ定義に基づく型を定義
+interface HealthResponse {
+  status: 'healthy' | 'unhealthy';
+  timestamp: string;
+  version?: string;
+}
+
+@Controller()
+export class HealthController {
+  @Get('/health')
+  async getHealth(): Promise<HealthResponse> {
+    // 仮実装: テストを通すための固定値を返す
+    return {
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      version: '1.0.0',
+    };
+  }
+}


### PR DESCRIPTION
## 概要
基本ヘルスチェックAPI（`/health`エンドポイント）の実装を完了しました。
TDDサイクルに従い、Red→Green実装を行いました。

## 実装内容
- ✅ `health.controller.spec.ts`: /health エンドポイントのテスト作成
- ✅ `health.controller.ts`: 最小限の実装（固定値返却）
- ✅ YAGNI原則に従い、必要最小限の機能のみ実装

## テスト結果
- バックエンドテスト: ✅ PASS (4 tests)
- ビルド: ✅ 成功
- リント: ✅ エラーなし（既存ファイルの警告のみ）

## 動作確認
```bash
curl http://localhost:3000/api/health
```
```json
{
  "status": "healthy",
  "timestamp": "2025-08-03T13:45:22.476Z",
  "version": "1.0.0"
}
```

## PR完了条件
- [x] 対象機能のテストが全てGreen
- [x] `npm run backend:lint` エラーなし
- [x] TypeScriptコンパイルエラーなし
- [x] 実装は最小限（ハードコードOK）

🤖 Generated with [Claude Code](https://claude.ai/code)