### PR TITLE
feat: WebSocket-PTY連携機能の実装 (Phase2.3)

### DIFF
--- a/.claude/todos/02-core-features.md
+++ b/.claude/todos/02-core-features.md
@@ -40,9 +40,9 @@ YAGNI 原則に従い、Amazon Q GUI の最小限動作に必要なコア機能�
 
 #### 3.1 WebSocket 経由で PTY コマンド実行
 
-- [ ] **Red**: 統合テスト作成 - WebSocket 経由のコマンド実行
-- [ ] **Green**: WebSocketGateway と PTYManager の連携実装
-- [ ] **動作確認**: WebSocket 経由でコマンドを実行し結果を取得
+- [x] **Red**: 統合テスト作成 - WebSocket 経由のコマンド実行
+- [x] **Green**: WebSocketGateway と PTYManager の連携実装
+- [x] **動作確認**: WebSocket 経由でコマンドを実行し結果を取得
 
 ## フロントエンドコア機能実装
 


### PR DESCRIPTION
## 概要
WebSocket経由でPTYコマンドを実行し、結果を返却する機能を実装しました。

## 実装内容
- WebSocketGatewayとPTYManagerServiceの連携
- メッセージ内のcommandプロパティを検出してコマンド実行
- 実行結果またはエラーをWebSocketで返却
- TDDサイクルに従った実装

## テスト
- ✅ WebSocket経由でコマンドを実行して結果を返す
- ✅ エラーコマンドの場合はエラーメッセージを返す
- ✅ 全バックエンドテスト成功
- ✅ リントチェック通過

## 変更ファイル
- `apps/backend/src/app/websocket.gateway.ts`: PTY連携ロジック追加
- `apps/backend/src/app/websocket.gateway.spec.ts`: 統合テスト追加
- `.claude/todos/02-core-features.md`: タスク完了

🤖 Generated with [Claude Code](https://claude.ai/code)